### PR TITLE
Add tester screening step and tag input component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -274,7 +274,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -284,7 +284,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -318,7 +318,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
       "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -377,7 +377,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,13 @@ enum SelectionStatus {
   BACKUP
 }
 
+enum ScreeningFlag {
+  FAKE_NAME
+  LOW_EFFORT
+  DUPLICATE_PATTERN
+  GENERIC_RESPONSE
+}
+
 model User {
   id            String    @id @default(cuid())
   name          String?
@@ -115,6 +122,7 @@ model Project {
   testerApplicants   TesterApplicant[]
   testerSelections   TesterSelection[]
   activeTestAssignments ActiveTestAssignment[]
+  testerScreeningFlags TesterScreeningFlag[]
   recruitmentSession RecruitmentSession?
 
   @@map("projects")
@@ -188,19 +196,21 @@ model QuestionMapping {
 }
 
 model TesterApplicant {
-  id              String   @id @default(cuid())
-  projectId       String
-  username        String
-  email           String
-  communityScore  Float    @default(0.0)
-  rawResponses    Json
-  tgtbtExtreme    Boolean  @default(false)
-  tgtbtOutlier    Boolean  @default(false)
-  createdAt       DateTime @default(now())
+  id                 String   @id @default(cuid())
+  projectId          String
+  username           String
+  email              String
+  communityScore     Float    @default(0.0)
+  rawResponses       Json
+  tgtbtExtreme       Boolean  @default(false)
+  tgtbtOutlier       Boolean  @default(false)
+  screeningExcluded  Boolean  @default(false)
+  createdAt          DateTime @default(now())
 
-  project          Project           @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  surveyResponses  SurveyResponse[]
-  testerSelection  TesterSelection?
+  project            Project               @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  surveyResponses    SurveyResponse[]
+  testerSelection    TesterSelection?
+  screeningFlags     TesterScreeningFlag[]
 
   @@unique([projectId, email])
   @@map("tester_applicants")
@@ -272,6 +282,22 @@ model ActiveTestAssignment {
 
   @@unique([projectId, email])
   @@map("active_test_assignments")
+}
+
+model TesterScreeningFlag {
+  id        String        @id @default(cuid())
+  projectId String
+  testerId  String
+  flag      ScreeningFlag
+  reason    String
+  excluded  Boolean       @default(false)
+  createdAt DateTime      @default(now())
+
+  project Project         @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  tester  TesterApplicant @relation(fields: [testerId], references: [id], onDelete: Cascade)
+
+  @@unique([testerId, flag])
+  @@map("tester_screening_flags")
 }
 
 model RecruitmentSession {

--- a/src/app/(dashboard)/dashboard/projects/[projectId]/mapping/page.tsx
+++ b/src/app/(dashboard)/dashboard/projects/[projectId]/mapping/page.tsx
@@ -117,7 +117,7 @@ export default function MappingPage({
     });
 
     if (res.ok) {
-      router.push(`/dashboard/projects/${projectId}/selection`);
+      router.push(`/dashboard/projects/${projectId}/screening`);
     } else {
       alert("Failed to save mappings");
       setSaving(false);

--- a/src/app/(dashboard)/dashboard/projects/[projectId]/requirements/page.tsx
+++ b/src/app/(dashboard)/dashboard/projects/[projectId]/requirements/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, use } from "react";
 import { useRouter } from "next/navigation";
 import { WorkflowSteps } from "@/components/layout/workflow-steps";
+import { TagInput } from "@/components/ui/tag-input";
 
 interface Requirement {
   name: string;
@@ -180,20 +181,12 @@ export default function RequirementsPage({
                   />
 
                   <div className="flex items-center gap-3">
-                    <input
-                      value={req.acceptedValues.join(", ")}
-                      onChange={(e) =>
-                        updateRequirement(
-                          i,
-                          "acceptedValues",
-                          e.target.value
-                            .split(",")
-                            .map((v) => v.trim())
-                            .filter(Boolean)
-                        )
+                    <TagInput
+                      values={req.acceptedValues}
+                      onChange={(vals) =>
+                        updateRequirement(i, "acceptedValues", vals)
                       }
-                      placeholder="Accepted values (comma-separated)"
-                      className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm outline-none focus:border-primary"
+                      placeholder="Type a value and press Enter"
                     />
                     {req.type === "SOFT" && (
                       <div className="flex items-center gap-1">

--- a/src/app/(dashboard)/dashboard/projects/[projectId]/screening/page.tsx
+++ b/src/app/(dashboard)/dashboard/projects/[projectId]/screening/page.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useState, useEffect, use } from "react";
+import { useRouter } from "next/navigation";
+import { WorkflowSteps } from "@/components/layout/workflow-steps";
+
+interface FlagData {
+  id: string;
+  flag: string;
+  reason: string;
+  excluded: boolean;
+}
+
+interface FlaggedTester {
+  testerId: string;
+  username: string;
+  email: string;
+  flags: FlagData[];
+}
+
+const FLAG_COLORS: Record<string, string> = {
+  FAKE_NAME: "bg-red-100 text-red-800",
+  LOW_EFFORT: "bg-orange-100 text-orange-800",
+  DUPLICATE_PATTERN: "bg-purple-100 text-purple-800",
+  GENERIC_RESPONSE: "bg-yellow-100 text-yellow-800",
+};
+
+const FLAG_LABELS: Record<string, string> = {
+  FAKE_NAME: "Fake Name",
+  LOW_EFFORT: "Low Effort",
+  DUPLICATE_PATTERN: "Duplicate Pattern",
+  GENERIC_RESPONSE: "Generic Response",
+};
+
+export default function ScreeningPage({
+  params,
+}: {
+  params: Promise<{ projectId: string }>;
+}) {
+  const { projectId } = use(params);
+  const router = useRouter();
+  const [screening, setScreening] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [flaggedTesters, setFlaggedTesters] = useState<FlaggedTester[]>([]);
+  const [totalApplicants, setTotalApplicants] = useState(0);
+  const [loaded, setLoaded] = useState(false);
+  const [decisions, setDecisions] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    loadScreeningResults();
+  }, [projectId]);
+
+  async function loadScreeningResults() {
+    const res = await fetch(`/api/projects/${projectId}/screening`);
+    if (res.ok) {
+      const data = await res.json();
+      setFlaggedTesters(data.flaggedTesters || []);
+      setTotalApplicants(data.totalApplicants || 0);
+
+      // Initialize decisions from existing data
+      const initial: Record<string, boolean> = {};
+      for (const tester of data.flaggedTesters || []) {
+        // Default to excluded for flagged testers
+        const anyExcluded = tester.flags.some(
+          (f: FlagData) => f.excluded
+        );
+        initial[tester.testerId] = anyExcluded;
+      }
+      setDecisions(initial);
+    }
+    setLoaded(true);
+  }
+
+  async function runScreening() {
+    setScreening(true);
+    const res = await fetch(`/api/projects/${projectId}/screening`, {
+      method: "POST",
+    });
+
+    if (res.ok) {
+      await loadScreeningResults();
+      // Default all flagged testers to excluded
+      const newDecisions: Record<string, boolean> = {};
+      for (const tester of flaggedTesters) {
+        newDecisions[tester.testerId] = true;
+      }
+      setDecisions(newDecisions);
+    }
+    setScreening(false);
+  }
+
+  function setAll(excluded: boolean) {
+    const updated: Record<string, boolean> = {};
+    for (const tester of flaggedTesters) {
+      updated[tester.testerId] = excluded;
+    }
+    setDecisions(updated);
+  }
+
+  async function confirmAndContinue() {
+    setSaving(true);
+    const decisionList = flaggedTesters.map((t) => ({
+      testerId: t.testerId,
+      excluded: decisions[t.testerId] ?? true,
+    }));
+
+    const res = await fetch(`/api/projects/${projectId}/screening`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ decisions: decisionList }),
+    });
+
+    if (res.ok) {
+      router.push(`/dashboard/projects/${projectId}/selection`);
+    } else {
+      alert("Failed to save screening decisions");
+      setSaving(false);
+    }
+  }
+
+  async function skipAndContinue() {
+    setSaving(true);
+    // Save empty decisions to advance workflow
+    const res = await fetch(`/api/projects/${projectId}/screening`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ decisions: [] }),
+    });
+
+    if (res.ok) {
+      router.push(`/dashboard/projects/${projectId}/selection`);
+    } else {
+      setSaving(false);
+    }
+  }
+
+  if (!loaded) {
+    return (
+      <div className="p-8">
+        <p className="text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  const hasResults = flaggedTesters.length > 0;
+  const hasRun = loaded && totalApplicants > 0 && flaggedTesters !== null;
+
+  return (
+    <div>
+      <WorkflowSteps currentStep="screening" projectId={projectId} />
+      <div className="mx-auto max-w-3xl p-8">
+        <h1 className="mb-6 text-2xl font-bold">Screening</h1>
+
+        {!hasResults ? (
+          <div className="text-center">
+            <p className="mb-4 text-muted-foreground">
+              Scan all applicants for suspicious patterns (fake names,
+              low-effort responses, duplicate accounts) before running the
+              solver.
+            </p>
+
+            <div className="flex justify-center gap-3">
+              <button
+                onClick={runScreening}
+                disabled={screening}
+                className="rounded-md bg-primary px-8 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {screening ? (
+                  <span className="flex items-center gap-2">
+                    <svg
+                      className="h-4 w-4 animate-spin"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                        className="opacity-25"
+                      />
+                      <path
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                        fill="currentColor"
+                        className="opacity-75"
+                      />
+                    </svg>
+                    Screening...
+                  </span>
+                ) : (
+                  "Run Screening"
+                )}
+              </button>
+
+              {hasRun && (
+                <button
+                  onClick={skipAndContinue}
+                  disabled={saving}
+                  className="rounded-md border border-border px-6 py-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
+                >
+                  Skip & Continue
+                </button>
+              )}
+            </div>
+
+            {loaded && totalApplicants > 0 && flaggedTesters.length === 0 && (
+              <div className="mt-6 rounded-lg border border-success/30 bg-success/10 p-4">
+                <p className="text-sm font-medium text-success">
+                  No suspicious testers detected. All clear!
+                </p>
+                <button
+                  onClick={skipAndContinue}
+                  disabled={saving}
+                  className="mt-3 rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                >
+                  {saving ? "Continuing..." : "Continue to Selection"}
+                </button>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div>
+            {/* Summary bar */}
+            <div className="mb-4 flex items-center justify-between rounded-lg border border-border bg-card p-4">
+              <p className="text-sm">
+                <span className="font-semibold text-warning">
+                  {flaggedTesters.length}
+                </span>{" "}
+                of{" "}
+                <span className="font-semibold">{totalApplicants}</span>{" "}
+                testers flagged
+              </p>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setAll(true)}
+                  className="rounded-md border border-border px-3 py-1 text-xs font-medium hover:bg-muted"
+                >
+                  Exclude All
+                </button>
+                <button
+                  onClick={() => setAll(false)}
+                  className="rounded-md border border-border px-3 py-1 text-xs font-medium hover:bg-muted"
+                >
+                  Include All
+                </button>
+              </div>
+            </div>
+
+            {/* Flagged testers list */}
+            <div className="space-y-3">
+              {flaggedTesters.map((tester) => {
+                const excluded = decisions[tester.testerId] ?? true;
+
+                return (
+                  <div
+                    key={tester.testerId}
+                    className={`rounded-lg border p-4 transition-colors ${
+                      excluded
+                        ? "border-destructive/30 bg-destructive/5"
+                        : "border-border bg-card"
+                    }`}
+                  >
+                    <div className="mb-2 flex items-start justify-between">
+                      <div>
+                        <p className="text-sm font-medium">
+                          {tester.username}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {tester.email}
+                        </p>
+                      </div>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() =>
+                            setDecisions((prev) => ({
+                              ...prev,
+                              [tester.testerId]: false,
+                            }))
+                          }
+                          className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                            !excluded
+                              ? "bg-success/10 text-success"
+                              : "border border-border hover:bg-muted"
+                          }`}
+                        >
+                          Include
+                        </button>
+                        <button
+                          onClick={() =>
+                            setDecisions((prev) => ({
+                              ...prev,
+                              [tester.testerId]: true,
+                            }))
+                          }
+                          className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                            excluded
+                              ? "bg-destructive/10 text-destructive"
+                              : "border border-border hover:bg-muted"
+                          }`}
+                        >
+                          Exclude
+                        </button>
+                      </div>
+                    </div>
+
+                    {/* Flag badges */}
+                    <div className="mb-2 flex flex-wrap gap-1.5">
+                      {tester.flags.map((f, i) => (
+                        <span
+                          key={i}
+                          className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                            FLAG_COLORS[f.flag] || "bg-muted text-muted-foreground"
+                          }`}
+                        >
+                          {FLAG_LABELS[f.flag] || f.flag}
+                        </span>
+                      ))}
+                    </div>
+
+                    {/* Reasons */}
+                    <div className="space-y-1">
+                      {tester.flags.map((f, i) => (
+                        <p key={i} className="text-xs text-muted-foreground">
+                          {f.reason}
+                        </p>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Actions */}
+            <div className="mt-6 flex gap-3">
+              <button
+                onClick={confirmAndContinue}
+                disabled={saving}
+                className="rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {saving ? "Saving..." : "Confirm & Continue"}
+              </button>
+              <button
+                onClick={runScreening}
+                disabled={screening}
+                className="rounded-md border border-border px-6 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+              >
+                Re-Run Screening
+              </button>
+              <button
+                onClick={() => router.back()}
+                className="rounded-md border border-border px-6 py-2 text-sm font-medium hover:bg-muted"
+              >
+                Back
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/projects/[projectId]/mapping/route.ts
+++ b/src/app/api/projects/[projectId]/mapping/route.ts
@@ -133,7 +133,7 @@ export async function POST(
 
     await prisma.recruitmentSession.update({
       where: { projectId },
-      data: { currentStep: "selection" },
+      data: { currentStep: "screening" },
     });
 
     return NextResponse.json({ success: true });

--- a/src/app/api/projects/[projectId]/screening/route.ts
+++ b/src/app/api/projects/[projectId]/screening/route.ts
@@ -1,0 +1,193 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db/prisma";
+import { runScreening, type TesterInput } from "@/lib/analysis/screening";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+
+  const project = await prisma.project.findFirst({
+    where: { id: projectId, userId: session.user.id },
+    include: {
+      testerApplicants: {
+        include: {
+          surveyResponses: {
+            include: { surveyQuestion: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (!project) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Transform to TesterInput format
+  const testers: TesterInput[] = project.testerApplicants.map((applicant) => ({
+    id: applicant.id,
+    username: applicant.username,
+    email: applicant.email,
+    responses: applicant.surveyResponses.map((r) => ({
+      questionText: r.surveyQuestion.questionText,
+      questionType: r.surveyQuestion.questionType,
+      value: r.responseValue,
+    })),
+  }));
+
+  // Run screening
+  const results = await runScreening(testers);
+
+  // Delete previous flags (idempotent re-runs)
+  await prisma.testerScreeningFlag.deleteMany({ where: { projectId } });
+
+  // Reset all screening exclusions for this project
+  await prisma.testerApplicant.updateMany({
+    where: { projectId },
+    data: { screeningExcluded: false },
+  });
+
+  // Insert new flags
+  const flagRecords = results.flatMap((result) =>
+    result.flags.map((f) => ({
+      projectId,
+      testerId: result.testerId,
+      flag: f.flag as "FAKE_NAME" | "LOW_EFFORT" | "DUPLICATE_PATTERN" | "GENERIC_RESPONSE",
+      reason: f.reason,
+      excluded: false,
+    }))
+  );
+
+  if (flagRecords.length > 0) {
+    // Use createMany but handle the unique constraint by inserting one-by-one
+    // since a tester might have multiple flags of the same type from different detectors
+    // We'll deduplicate by keeping the first flag per (testerId, flag) combo
+    const seen = new Set<string>();
+    const dedupedRecords = flagRecords.filter((r) => {
+      const key = `${r.testerId}:${r.flag}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    await prisma.testerScreeningFlag.createMany({ data: dedupedRecords });
+  }
+
+  // Update workflow step
+  await prisma.recruitmentSession.update({
+    where: { projectId },
+    data: { currentStep: "screening" },
+  });
+
+  const flaggedTesterIds = new Set(results.map((r) => r.testerId));
+
+  return NextResponse.json({
+    flaggedCount: flaggedTesterIds.size,
+    totalApplicants: testers.length,
+    totalFlags: flagRecords.length,
+  });
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+
+  const flags = await prisma.testerScreeningFlag.findMany({
+    where: { projectId },
+    include: {
+      tester: {
+        select: { id: true, username: true, email: true },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const totalApplicants = await prisma.testerApplicant.count({
+    where: { projectId },
+  });
+
+  // Group by tester
+  const testerMap = new Map<
+    string,
+    {
+      testerId: string;
+      username: string;
+      email: string;
+      flags: { id: string; flag: string; reason: string; excluded: boolean }[];
+    }
+  >();
+
+  for (const f of flags) {
+    if (!testerMap.has(f.testerId)) {
+      testerMap.set(f.testerId, {
+        testerId: f.testerId,
+        username: f.tester.username,
+        email: f.tester.email,
+        flags: [],
+      });
+    }
+    testerMap.get(f.testerId)!.flags.push({
+      id: f.id,
+      flag: f.flag,
+      reason: f.reason,
+      excluded: f.excluded,
+    });
+  }
+
+  return NextResponse.json({
+    flaggedTesters: Array.from(testerMap.values()),
+    totalApplicants,
+  });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+  const body = await req.json();
+  const { decisions } = body as {
+    decisions: { testerId: string; excluded: boolean }[];
+  };
+
+  // Update flags and applicant records
+  for (const decision of decisions) {
+    await prisma.testerScreeningFlag.updateMany({
+      where: { projectId, testerId: decision.testerId },
+      data: { excluded: decision.excluded },
+    });
+
+    await prisma.testerApplicant.update({
+      where: { id: decision.testerId },
+      data: { screeningExcluded: decision.excluded },
+    });
+  }
+
+  // Advance workflow step
+  await prisma.recruitmentSession.update({
+    where: { projectId },
+    data: { currentStep: "selection" },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/projects/[projectId]/solve/route.ts
+++ b/src/app/api/projects/[projectId]/solve/route.ts
@@ -31,6 +31,20 @@ export async function POST(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
+  // Guard: ensure screening step is completed
+  const recruitmentSession = await prisma.recruitmentSession.findUnique({
+    where: { projectId },
+  });
+  if (
+    recruitmentSession?.currentStep === "screening" ||
+    recruitmentSession?.currentStep === "mapping"
+  ) {
+    return NextResponse.json(
+      { error: "Please complete the screening step first" },
+      { status: 400 }
+    );
+  }
+
   // Load global blocklist and golden tickets
   const [blocklistEntries, goldenTicketEntries] = await Promise.all([
     prisma.blocklistEntry.findMany(),

--- a/src/components/layout/workflow-steps.tsx
+++ b/src/components/layout/workflow-steps.tsx
@@ -4,6 +4,7 @@ const steps = [
   { key: "upload", label: "Upload Data" },
   { key: "requirements", label: "Requirements" },
   { key: "mapping", label: "Map Questions" },
+  { key: "screening", label: "Screening" },
   { key: "selection", label: "Run Selection" },
   { key: "review", label: "Review Testers" },
   { key: "export", label: "Export" },

--- a/src/components/ui/tag-input.tsx
+++ b/src/components/ui/tag-input.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState, useRef, type KeyboardEvent } from "react";
+
+interface TagInputProps {
+  values: string[];
+  onChange: (values: string[]) => void;
+  placeholder?: string;
+}
+
+export function TagInput({ values, onChange, placeholder }: TagInputProps) {
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function addTag(raw: string) {
+    const tag = raw.trim();
+    if (!tag) return;
+    if (values.some((v) => v.toLowerCase() === tag.toLowerCase())) return;
+    onChange([...values, tag]);
+    setInputValue("");
+  }
+
+  function removeTag(index: number) {
+    onChange(values.filter((_, i) => i !== index));
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      addTag(inputValue);
+    } else if (e.key === "Backspace" && inputValue === "" && values.length > 0) {
+      removeTag(values.length - 1);
+    }
+  }
+
+  function handleBlur() {
+    if (inputValue.trim()) {
+      addTag(inputValue);
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-1 flex-wrap items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1.5 focus-within:border-primary"
+      onClick={() => inputRef.current?.focus()}
+    >
+      {values.map((tag, i) => (
+        <span
+          key={i}
+          className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+        >
+          {tag}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              removeTag(i);
+            }}
+            className="ml-0.5 text-primary/60 hover:text-primary"
+          >
+            &times;
+          </button>
+        </span>
+      ))}
+      <input
+        ref={inputRef}
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
+        placeholder={values.length === 0 ? placeholder : ""}
+        className="min-w-[120px] flex-1 bg-transparent text-sm outline-none"
+      />
+    </div>
+  );
+}

--- a/src/lib/analysis/claude-client.ts
+++ b/src/lib/analysis/claude-client.ts
@@ -52,6 +52,83 @@ Reply in this exact JSON format:
   }
 }
 
+// ── Screening ──────────────────────────────────────────────────
+
+export interface ScreeningAnalysisResult {
+  flagged: boolean;
+  reason: string;
+}
+
+async function screenSingleResponse(
+  text: string,
+  context?: string
+): Promise<ScreeningAnalysisResult> {
+  const message = await client.messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 200,
+    messages: [
+      {
+        role: "user",
+        content: `You are screening beta tester survey responses for quality. Analyze the following responses and determine if they appear to be generic, templated, copy-pasted, or otherwise not genuine.
+
+${context ? `Context: ${context}\n` : ""}
+Responses:
+${text}
+
+Reply in this exact JSON format:
+{"flagged": false, "reason": "Brief explanation"}
+
+Set "flagged" to true ONLY if the responses show clear signs of being generic/templated/fake (e.g., formulaic language, copy-paste patterns, suspiciously perfect responses, no personal detail). Normal short or simple responses should NOT be flagged.`,
+      },
+    ],
+  });
+
+  const content = message.content[0];
+  if (content.type !== "text") {
+    throw new Error("Unexpected response type");
+  }
+
+  try {
+    const parsed = JSON.parse(content.text);
+    return {
+      flagged: parsed.flagged === true,
+      reason: parsed.reason || "No reason provided",
+    };
+  } catch {
+    return { flagged: false, reason: "Could not parse response" };
+  }
+}
+
+/**
+ * Batch screen responses for generic/templated content (5 concurrent requests).
+ */
+export async function screenBatchResponses(
+  items: { testerId: string; text: string; context?: string }[]
+): Promise<Map<string, ScreeningAnalysisResult>> {
+  const results = new Map<string, ScreeningAnalysisResult>();
+  const concurrencyLimit = 5;
+
+  for (let i = 0; i < items.length; i += concurrencyLimit) {
+    const batch = items.slice(i, i + concurrencyLimit);
+    const batchResults = await Promise.allSettled(
+      batch.map(async (item) => {
+        const result = await screenSingleResponse(item.text, item.context);
+        return { testerId: item.testerId, result };
+      })
+    );
+
+    for (const r of batchResults) {
+      if (r.status === "fulfilled") {
+        results.set(r.value.testerId, r.value.result);
+      }
+    }
+  }
+
+  return results;
+}
+
+// ── Sentiment ──────────────────────────────────────────────────
+
 /**
  * Batch analyze with concurrency limiting (5 concurrent requests).
  */

--- a/src/lib/analysis/screening.test.ts
+++ b/src/lib/analysis/screening.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./claude-client", () => ({
+  screenBatchResponses: vi.fn(),
+  analyzeSentiment: vi.fn(),
+  batchAnalyzeSentiment: vi.fn(),
+}));
+
+import {
+  detectFakeNames,
+  detectLowEffort,
+  detectDuplicatePatterns,
+  runScreening,
+  resetCircuitBreaker,
+  type TesterInput,
+} from "./screening";
+import { screenBatchResponses } from "./claude-client";
+
+const mockedScreenBatch = vi.mocked(screenBatchResponses);
+
+function makeTester(overrides: Partial<TesterInput> = {}): TesterInput {
+  return {
+    id: overrides.id ?? "t1",
+    username: overrides.username ?? "normaluser",
+    email: overrides.email ?? "user@gmail.com",
+    responses: overrides.responses ?? [],
+  };
+}
+
+describe("detectFakeNames", () => {
+  it("flags single-character username", () => {
+    const results = detectFakeNames([makeTester({ username: "x" })]);
+    expect(results).toHaveLength(1);
+    expect(results[0].flags[0].flag).toBe("FAKE_NAME");
+    expect(results[0].flags[0].reason).toContain("1 character");
+  });
+
+  it("flags keyboard mash", () => {
+    const results = detectFakeNames([makeTester({ username: "asdfghjk" })]);
+    expect(results).toHaveLength(1);
+    expect(results[0].flags[0].reason).toContain("keyboard mash");
+  });
+
+  it("flags placeholder names", () => {
+    const names = ["test", "Test User", "demo", "n/a", "xxx"];
+    for (const name of names) {
+      const results = detectFakeNames([makeTester({ username: name })]);
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      const hasFlag = results.some((r) =>
+        r.flags.some((f) => f.flag === "FAKE_NAME")
+      );
+      expect(hasFlag).toBe(true);
+    }
+  });
+
+  it("flags all-same-character names", () => {
+    const results = detectFakeNames([makeTester({ username: "aaaa" })]);
+    expect(results).toHaveLength(1);
+    expect(results[0].flags[0].reason).toContain("repeated character");
+  });
+
+  it("flags no-vowel names (length > 3)", () => {
+    const results = detectFakeNames([makeTester({ username: "brtfg" })]);
+    expect(results).toHaveLength(1);
+    expect(results[0].flags[0].reason).toContain("no vowels");
+  });
+
+  it("does not flag normal names", () => {
+    const results = detectFakeNames([
+      makeTester({ username: "Sarah Connor" }),
+      makeTester({ id: "t2", username: "john_smith" }),
+      makeTester({ id: "t3", username: "María García" }),
+    ]);
+    expect(results).toHaveLength(0);
+  });
+
+  it("does not flag short names with vowels", () => {
+    const results = detectFakeNames([makeTester({ username: "Joe" })]);
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe("detectLowEffort", () => {
+  it("flags very short open-text responses", () => {
+    const tester = makeTester({
+      responses: [
+        { questionText: "Why do you want to test?", questionType: "text", value: "idk" },
+      ],
+    });
+    const results = detectLowEffort([tester]);
+    expect(results).toHaveLength(1);
+    expect(results[0].flags[0].flag).toBe("LOW_EFFORT");
+    expect(results[0].flags[0].reason).toContain("short response");
+  });
+
+  it("flags single-word responses to open questions", () => {
+    const tester = makeTester({
+      responses: [
+        { questionText: "Describe your experience", questionType: "text", value: "good" },
+      ],
+    });
+    const results = detectLowEffort([tester]);
+    expect(results).toHaveLength(1);
+  });
+
+  it("flags repeating character patterns", () => {
+    const tester = makeTester({
+      responses: [
+        { questionText: "Tell us more", questionType: "text", value: "hahahahahahaha" },
+      ],
+    });
+    const results = detectLowEffort([tester]);
+    expect(results).toHaveLength(1);
+    expect(results[0].flags[0].reason).toContain("Repeating");
+  });
+
+  it("ignores non-text question types", () => {
+    const tester = makeTester({
+      responses: [
+        { questionText: "OS?", questionType: "choice", value: "Yes" },
+      ],
+    });
+    const results = detectLowEffort([tester]);
+    expect(results).toHaveLength(0);
+  });
+
+  it("does not flag reasonable responses", () => {
+    const tester = makeTester({
+      responses: [
+        {
+          questionText: "Why do you want to test?",
+          questionType: "text",
+          value: "I have been a beta tester for several years and enjoy providing detailed feedback",
+        },
+      ],
+    });
+    const results = detectLowEffort([tester]);
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe("detectDuplicatePatterns", () => {
+  it("flags near-identical usernames (with numeric suffixes)", () => {
+    const testers = [
+      makeTester({ id: "t1", username: "botuser1" }),
+      makeTester({ id: "t2", username: "botuser2" }),
+    ];
+    const results = detectDuplicatePatterns(testers);
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    const allFlags = results.flatMap((r) => r.flags);
+    expect(allFlags.some((f) => f.flag === "DUPLICATE_PATTERN")).toBe(true);
+  });
+
+  it("flags identical free-text responses across testers", () => {
+    const sharedResponse = "I am very excited to test this product and provide feedback";
+    const testers = [
+      makeTester({
+        id: "t1",
+        username: "alice",
+        responses: [{ questionText: "Why?", questionType: "text", value: sharedResponse }],
+      }),
+      makeTester({
+        id: "t2",
+        username: "bob",
+        responses: [{ questionText: "Why?", questionType: "text", value: sharedResponse }],
+      }),
+    ];
+    const results = detectDuplicatePatterns(testers);
+    expect(results.length).toBe(2);
+    expect(results[0].flags[0].reason).toContain("Identical response");
+  });
+
+  it("flags uncommon shared email domains (3+)", () => {
+    const testers = [
+      makeTester({ id: "t1", username: "alice", email: "a@fakecorp.biz" }),
+      makeTester({ id: "t2", username: "robert", email: "b@fakecorp.biz" }),
+      makeTester({ id: "t3", username: "charlie", email: "c@fakecorp.biz" }),
+    ];
+    const results = detectDuplicatePatterns(testers);
+    expect(results.length).toBe(3);
+    const domainFlags = results.flatMap((r) =>
+      r.flags.filter((f) => f.reason.includes("@fakecorp.biz"))
+    );
+    expect(domainFlags.length).toBe(3);
+  });
+
+  it("does not flag common email domains", () => {
+    const testers = [
+      makeTester({ id: "t1", email: "a@gmail.com" }),
+      makeTester({ id: "t2", email: "b@gmail.com" }),
+      makeTester({ id: "t3", email: "c@gmail.com" }),
+    ];
+    const results = detectDuplicatePatterns(testers);
+    const domainFlags = results.flatMap((r) =>
+      r.flags.filter((f) => f.reason.includes("@gmail.com"))
+    );
+    expect(domainFlags).toHaveLength(0);
+  });
+
+  it("does not flag distinct usernames", () => {
+    const testers = [
+      makeTester({ id: "t1", username: "alice" }),
+      makeTester({ id: "t2", username: "robert" }),
+    ];
+    const results = detectDuplicatePatterns(testers);
+    const nameFlags = results.flatMap((r) =>
+      r.flags.filter((f) => f.reason.includes("Username similar"))
+    );
+    expect(nameFlags).toHaveLength(0);
+  });
+});
+
+describe("runScreening", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    resetCircuitBreaker();
+  });
+
+  it("merges flags from all tiers", async () => {
+    const originalKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = "test-key";
+
+    // Mock Claude to flag a tester
+    mockedScreenBatch.mockResolvedValue(
+      new Map([
+        ["t1", { flagged: true, reason: "Generic template response" }],
+      ])
+    );
+
+    const testers = [
+      makeTester({
+        id: "t1",
+        username: "asdfgh",
+        responses: [
+          {
+            questionText: "Why test?",
+            questionType: "text",
+            value: "I would love to help test this amazing product for your company",
+          },
+        ],
+      }),
+    ];
+
+    const results = await runScreening(testers);
+    expect(results).toHaveLength(1);
+    expect(results[0].testerId).toBe("t1");
+
+    const flagTypes = results[0].flags.map((f) => f.flag);
+    expect(flagTypes).toContain("FAKE_NAME");
+    expect(flagTypes).toContain("GENERIC_RESPONSE");
+
+    process.env.ANTHROPIC_API_KEY = originalKey;
+  });
+
+  it("works without Claude API key", async () => {
+    const originalKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+
+    const testers = [makeTester({ username: "qwerty123" })];
+    const results = await runScreening(testers);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].flags[0].flag).toBe("FAKE_NAME");
+    expect(mockedScreenBatch).not.toHaveBeenCalled();
+
+    process.env.ANTHROPIC_API_KEY = originalKey;
+  });
+
+  it("returns empty for clean testers", async () => {
+    mockedScreenBatch.mockResolvedValue(new Map());
+
+    const testers = [
+      makeTester({
+        id: "t1",
+        username: "Sarah Connor",
+        email: "sarah@gmail.com",
+        responses: [
+          {
+            questionText: "Why test?",
+            questionType: "text",
+            value: "I have been beta testing software for five years and enjoy finding edge cases",
+          },
+        ],
+      }),
+    ];
+
+    const results = await runScreening(testers);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/src/lib/analysis/screening.ts
+++ b/src/lib/analysis/screening.ts
@@ -1,0 +1,406 @@
+/**
+ * Two-tier screening module for detecting suspicious/fake testers.
+ *
+ * Tier 1: Local heuristics (fast, no API, always runs)
+ *   - Fake/gibberish names
+ *   - Low-effort open text responses
+ *   - Duplicate/bot patterns
+ *
+ * Tier 2: Claude API (nuanced, skipped if unavailable)
+ *   - Generic/templated response detection
+ */
+
+import { screenBatchResponses } from "./claude-client";
+
+// ── Types ──────────────────────────────────────────────────────
+
+export type FlagType =
+  | "FAKE_NAME"
+  | "LOW_EFFORT"
+  | "DUPLICATE_PATTERN"
+  | "GENERIC_RESPONSE";
+
+export interface ScreeningFlag {
+  flag: FlagType;
+  reason: string;
+}
+
+export interface ScreeningResult {
+  testerId: string;
+  flags: ScreeningFlag[];
+}
+
+export interface TesterInput {
+  id: string;
+  username: string;
+  email: string;
+  responses: { questionText: string; questionType: string; value: string }[];
+}
+
+// ── Circuit Breaker (same pattern as sentiment.ts) ─────────────
+
+let consecutiveFailures = 0;
+let circuitOpenUntil = 0;
+const FAILURE_THRESHOLD = 3;
+const CIRCUIT_OPEN_MS = 60_000;
+
+function isCircuitOpen(): boolean {
+  if (consecutiveFailures >= FAILURE_THRESHOLD) {
+    if (Date.now() < circuitOpenUntil) return true;
+    consecutiveFailures = FAILURE_THRESHOLD - 1;
+  }
+  return false;
+}
+
+function recordSuccess() {
+  consecutiveFailures = 0;
+}
+
+function recordFailure() {
+  consecutiveFailures++;
+  if (consecutiveFailures >= FAILURE_THRESHOLD) {
+    circuitOpenUntil = Date.now() + CIRCUIT_OPEN_MS;
+  }
+}
+
+// For testing
+export function resetCircuitBreaker() {
+  consecutiveFailures = 0;
+  circuitOpenUntil = 0;
+}
+
+// ── Tier 1: Local Heuristics ──────────────────────────────────
+
+const KEYBOARD_PATTERNS = [
+  "qwerty",
+  "qwertz",
+  "asdf",
+  "zxcv",
+  "wasd",
+  "hjkl",
+  "1234",
+  "abcd",
+];
+
+const PLACEHOLDER_NAMES = [
+  "test",
+  "tester",
+  "user",
+  "demo",
+  "admin",
+  "sample",
+  "example",
+  "none",
+  "n/a",
+  "na",
+  "null",
+  "undefined",
+  "xxx",
+  "aaa",
+  "abc",
+  "foo",
+  "bar",
+  "john doe",
+  "jane doe",
+  "test user",
+];
+
+function hasVowels(str: string): boolean {
+  return /[aeiou]/i.test(str);
+}
+
+function isAllSameChar(str: string): boolean {
+  if (str.length < 2) return false;
+  return str.split("").every((c) => c === str[0]);
+}
+
+function isKeyboardMash(str: string): boolean {
+  const lower = str.toLowerCase().replace(/[^a-z]/g, "");
+  return KEYBOARD_PATTERNS.some((p) => lower.includes(p));
+}
+
+export function detectFakeNames(testers: TesterInput[]): ScreeningResult[] {
+  const results: ScreeningResult[] = [];
+
+  for (const tester of testers) {
+    const name = tester.username.trim();
+    const lower = name.toLowerCase();
+    const flags: ScreeningFlag[] = [];
+
+    if (name.length <= 1) {
+      flags.push({ flag: "FAKE_NAME", reason: `Username is only ${name.length} character(s)` });
+    } else if (isAllSameChar(lower)) {
+      flags.push({ flag: "FAKE_NAME", reason: `Username is repeated character: "${name}"` });
+    } else if (isKeyboardMash(lower)) {
+      flags.push({ flag: "FAKE_NAME", reason: `Username looks like a keyboard mash: "${name}"` });
+    } else if (PLACEHOLDER_NAMES.includes(lower)) {
+      flags.push({ flag: "FAKE_NAME", reason: `Username matches placeholder: "${name}"` });
+    } else if (lower.length > 3 && !hasVowels(lower)) {
+      flags.push({ flag: "FAKE_NAME", reason: `Username has no vowels: "${name}"` });
+    }
+
+    if (flags.length > 0) {
+      results.push({ testerId: tester.id, flags });
+    }
+  }
+
+  return results;
+}
+
+function isOpenTextQuestion(questionType: string): boolean {
+  return questionType === "text" || questionType === "open";
+}
+
+function hasRepeatingPattern(str: string): boolean {
+  const lower = str.toLowerCase().replace(/\s/g, "");
+  if (lower.length < 4) return false;
+  // Check 1-3 char repeating patterns
+  for (let len = 1; len <= 3; len++) {
+    const pattern = lower.slice(0, len);
+    const repeated = pattern.repeat(Math.ceil(lower.length / len)).slice(0, lower.length);
+    if (repeated === lower) return true;
+  }
+  return false;
+}
+
+export function detectLowEffort(testers: TesterInput[]): ScreeningResult[] {
+  const results: ScreeningResult[] = [];
+
+  for (const tester of testers) {
+    const flags: ScreeningFlag[] = [];
+    const textResponses = tester.responses.filter((r) =>
+      isOpenTextQuestion(r.questionType)
+    );
+
+    for (const resp of textResponses) {
+      const val = resp.value.trim();
+      if (!val) continue;
+
+      if (val.length < 10) {
+        flags.push({
+          flag: "LOW_EFFORT",
+          reason: `Very short response (${val.length} chars) to "${resp.questionText}"`,
+        });
+      } else if (hasRepeatingPattern(val)) {
+        flags.push({
+          flag: "LOW_EFFORT",
+          reason: `Repeating character pattern in response to "${resp.questionText}"`,
+        });
+      } else if (val.split(/\s+/).length === 1 && val.length < 20) {
+        flags.push({
+          flag: "LOW_EFFORT",
+          reason: `Single-word response to open question "${resp.questionText}"`,
+        });
+      }
+    }
+
+    if (flags.length > 0) {
+      results.push({ testerId: tester.id, flags });
+    }
+  }
+
+  return results;
+}
+
+const COMMON_EMAIL_DOMAINS = new Set([
+  "gmail.com",
+  "yahoo.com",
+  "outlook.com",
+  "hotmail.com",
+  "icloud.com",
+  "aol.com",
+  "live.com",
+  "msn.com",
+  "mail.com",
+  "protonmail.com",
+  "proton.me",
+  "ymail.com",
+]);
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+    }
+  }
+  return dp[m][n];
+}
+
+function stripTrailingDigits(s: string): string {
+  return s.replace(/\d+$/, "");
+}
+
+export function detectDuplicatePatterns(testers: TesterInput[]): ScreeningResult[] {
+  const flagMap = new Map<string, ScreeningFlag[]>();
+
+  // 1. Near-identical usernames
+  for (let i = 0; i < testers.length; i++) {
+    for (let j = i + 1; j < testers.length; j++) {
+      const a = stripTrailingDigits(testers[i].username.toLowerCase());
+      const b = stripTrailingDigits(testers[j].username.toLowerCase());
+      if (a.length > 2 && b.length > 2 && levenshtein(a, b) <= 2) {
+        const flag: ScreeningFlag = {
+          flag: "DUPLICATE_PATTERN",
+          reason: `Username similar to "${testers[j].username}"`,
+        };
+        const flagJ: ScreeningFlag = {
+          flag: "DUPLICATE_PATTERN",
+          reason: `Username similar to "${testers[i].username}"`,
+        };
+        if (!flagMap.has(testers[i].id)) flagMap.set(testers[i].id, []);
+        flagMap.get(testers[i].id)!.push(flag);
+        if (!flagMap.has(testers[j].id)) flagMap.set(testers[j].id, []);
+        flagMap.get(testers[j].id)!.push(flagJ);
+      }
+    }
+  }
+
+  // 2. Matching free-text responses across testers
+  const responseGroups = new Map<string, string[]>();
+  for (const tester of testers) {
+    for (const resp of tester.responses) {
+      if (!isOpenTextQuestion(resp.questionType)) continue;
+      const normalized = resp.value.toLowerCase().trim();
+      if (normalized.length < 15) continue; // skip very short
+      if (!responseGroups.has(normalized)) responseGroups.set(normalized, []);
+      responseGroups.get(normalized)!.push(tester.id);
+    }
+  }
+  for (const [text, testerIds] of responseGroups) {
+    if (testerIds.length > 1) {
+      const snippet = text.length > 40 ? text.slice(0, 40) + "..." : text;
+      for (const id of testerIds) {
+        if (!flagMap.has(id)) flagMap.set(id, []);
+        flagMap.get(id)!.push({
+          flag: "DUPLICATE_PATTERN",
+          reason: `Identical response shared with ${testerIds.length - 1} other tester(s): "${snippet}"`,
+        });
+      }
+    }
+  }
+
+  // 3. Uncommon shared email domain (3+ testers)
+  const domainGroups = new Map<string, string[]>();
+  for (const tester of testers) {
+    const domain = tester.email.split("@")[1]?.toLowerCase();
+    if (!domain || COMMON_EMAIL_DOMAINS.has(domain)) continue;
+    if (!domainGroups.has(domain)) domainGroups.set(domain, []);
+    domainGroups.get(domain)!.push(tester.id);
+  }
+  for (const [domain, testerIds] of domainGroups) {
+    if (testerIds.length >= 3) {
+      for (const id of testerIds) {
+        if (!flagMap.has(id)) flagMap.set(id, []);
+        flagMap.get(id)!.push({
+          flag: "DUPLICATE_PATTERN",
+          reason: `${testerIds.length} testers share uncommon email domain @${domain}`,
+        });
+      }
+    }
+  }
+
+  return Array.from(flagMap.entries()).map(([testerId, flags]) => ({
+    testerId,
+    flags,
+  }));
+}
+
+// ── Tier 2: Claude API ─────────────────────────────────────────
+
+async function detectGenericResponses(
+  testers: TesterInput[]
+): Promise<ScreeningResult[]> {
+  if (!process.env.ANTHROPIC_API_KEY || isCircuitOpen()) {
+    return [];
+  }
+
+  // Collect text responses for screening
+  const items: { testerId: string; text: string; context: string }[] = [];
+  for (const tester of testers) {
+    const textResponses = tester.responses.filter(
+      (r) => isOpenTextQuestion(r.questionType) && r.value.trim().length >= 15
+    );
+    if (textResponses.length === 0) continue;
+
+    const combined = textResponses
+      .map((r) => `Q: ${r.questionText}\nA: ${r.value}`)
+      .join("\n\n");
+
+    items.push({
+      testerId: tester.id,
+      text: combined,
+      context: `Tester "${tester.username}" — all open-text responses`,
+    });
+  }
+
+  if (items.length === 0) return [];
+
+  try {
+    const claudeResults = await screenBatchResponses(items);
+    recordSuccess();
+
+    const results: ScreeningResult[] = [];
+    for (const [testerId, result] of claudeResults) {
+      if (result.flagged) {
+        results.push({
+          testerId,
+          flags: [
+            {
+              flag: "GENERIC_RESPONSE",
+              reason: result.reason,
+            },
+          ],
+        });
+      }
+    }
+    return results;
+  } catch (error) {
+    console.warn("Claude screening failed, skipping Tier 2:", error);
+    recordFailure();
+    return [];
+  }
+}
+
+// ── Orchestrator ───────────────────────────────────────────────
+
+function mergeResults(resultSets: ScreeningResult[][]): ScreeningResult[] {
+  const merged = new Map<string, ScreeningFlag[]>();
+
+  for (const results of resultSets) {
+    for (const result of results) {
+      if (!merged.has(result.testerId)) {
+        merged.set(result.testerId, []);
+      }
+      merged.get(result.testerId)!.push(...result.flags);
+    }
+  }
+
+  return Array.from(merged.entries()).map(([testerId, flags]) => ({
+    testerId,
+    flags,
+  }));
+}
+
+export async function runScreening(
+  testers: TesterInput[]
+): Promise<ScreeningResult[]> {
+  // Tier 1: Local heuristics (fast)
+  const nameFlags = detectFakeNames(testers);
+  const effortFlags = detectLowEffort(testers);
+  const duplicateFlags = detectDuplicatePatterns(testers);
+
+  // Tier 2: Claude API (may be skipped)
+  const genericFlags = await detectGenericResponses(testers);
+
+  return mergeResults([nameFlags, effortFlags, duplicateFlags, genericFlags]);
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -82,7 +82,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     async authorized({ auth, request }) {
       const isLoggedIn = !!auth?.user;
       const isOnDashboard = request.nextUrl.pathname.startsWith("/dashboard");
-      const isOnApi = request.nextUrl.pathname.startsWith("/api");
+      const isOnAuthApi = request.nextUrl.pathname.startsWith("/api/auth");
+      const isOnApi = request.nextUrl.pathname.startsWith("/api") && !isOnAuthApi;
       const isOnLogin = request.nextUrl.pathname === "/login";
 
       if (isOnDashboard || isOnApi) {

--- a/src/lib/solver/constraints.test.ts
+++ b/src/lib/solver/constraints.test.ts
@@ -19,6 +19,7 @@ function makeTester(overrides: Partial<TesterData> = {}): TesterData {
     tgtbtOutlier: false,
     responses: {},
     isBlocklisted: false,
+    isScreeningExcluded: false,
     isGoldenTicket: false,
     goldenTicketPriority: 0,
     activeTestCount: 0,
@@ -66,6 +67,16 @@ describe("preFilter", () => {
     const testers = [
       makeTester({ id: "t1", hardRequirementsMet: false }),
       makeTester({ id: "t2", hardRequirementsMet: true }),
+    ];
+    const result = preFilter(testers);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("t2");
+  });
+
+  it("removes screening-excluded testers", () => {
+    const testers = [
+      makeTester({ id: "t1", isScreeningExcluded: true }),
+      makeTester({ id: "t2", isScreeningExcluded: false }),
     ];
     const result = preFilter(testers);
     expect(result).toHaveLength(1);
@@ -184,6 +195,7 @@ describe("prepareTesterData", () => {
       communityScore: 0.9,
       tgtbtExtreme: false,
       tgtbtOutlier: false,
+      screeningExcluded: false,
       surveyResponses: [
         { surveyQuestionId: "q1", responseValue: "Windows" },
         { surveyQuestionId: "q2", responseValue: "18-25" },
@@ -196,6 +208,7 @@ describe("prepareTesterData", () => {
       communityScore: 0.5,
       tgtbtExtreme: true,
       tgtbtOutlier: false,
+      screeningExcluded: false,
       surveyResponses: [
         { surveyQuestionId: "q1", responseValue: "Mac" },
         { surveyQuestionId: "q2", responseValue: "26-35" },

--- a/src/lib/solver/constraints.ts
+++ b/src/lib/solver/constraints.ts
@@ -12,6 +12,7 @@ export interface TesterData {
   tgtbtOutlier: boolean;
   responses: Record<string, string>; // questionId -> responseValue
   isBlocklisted: boolean;
+  isScreeningExcluded: boolean;
   isGoldenTicket: boolean;
   goldenTicketPriority: number;
   activeTestCount: number;
@@ -53,7 +54,9 @@ export const DEFAULT_WEIGHTS: SolverConfig["weights"] = {
  * Pre-filter: remove blocklisted and hard-requirement-failing testers.
  */
 export function preFilter(testers: TesterData[]): TesterData[] {
-  return testers.filter((t) => !t.isBlocklisted && t.hardRequirementsMet);
+  return testers.filter(
+    (t) => !t.isBlocklisted && !t.isScreeningExcluded && t.hardRequirementsMet
+  );
 }
 
 /**
@@ -129,6 +132,7 @@ export function prepareTesterData(
     communityScore: number;
     tgtbtExtreme: boolean;
     tgtbtOutlier: boolean;
+    screeningExcluded: boolean;
     surveyResponses: { surveyQuestionId: string; responseValue: string }[];
   }[],
   hardRequirements: {
@@ -209,6 +213,7 @@ export function prepareTesterData(
       tgtbtOutlier: applicant.tgtbtOutlier,
       responses,
       isBlocklisted,
+      isScreeningExcluded: applicant.screeningExcluded,
       isGoldenTicket: gtPriority > 0,
       goldenTicketPriority: gtPriority,
       activeTestCount: activeTestEmails.has(applicant.email.toLowerCase())

--- a/src/lib/solver/z3-solver.test.ts
+++ b/src/lib/solver/z3-solver.test.ts
@@ -12,6 +12,7 @@ function makeTester(overrides: Partial<TesterData> = {}): TesterData {
     tgtbtOutlier: false,
     responses: {},
     isBlocklisted: false,
+    isScreeningExcluded: false,
     isGoldenTicket: false,
     goldenTicketPriority: 0,
     activeTestCount: 0,


### PR DESCRIPTION
## Summary

- **Tester screening workflow step**: Adds a new step between "Map Questions" and "Run Selection" that scans all applicants for suspicious patterns before they enter the solver. Two-tier detection: fast local heuristics (fake names, low-effort responses, duplicate usernames/emails, identical answers) plus optional Claude API screening for generic/templated responses (with circuit breaker). Users can review flagged testers and include/exclude them individually before proceeding.
- **Tag input component**: Replaces the broken comma-separated text input on the requirements page with a proper `TagInput` widget — adds values on Enter/comma/blur, supports backspace deletion, and prevents the old input from eating commas on every keystroke.
- **Auth fix**: API route middleware now avoids blocking `/api/auth` callback routes.

### New files (5)
- `src/lib/analysis/screening.ts` — screening detection module (fake names, low effort, duplicate patterns, Claude API generic response detection)
- `src/lib/analysis/screening.test.ts` — 20 unit tests covering all screening tiers
- `src/components/ui/tag-input.tsx` — reusable tag input component
- `src/app/(dashboard)/dashboard/projects/[projectId]/screening/page.tsx` — screening review UI
- `src/app/api/projects/[projectId]/screening/route.ts` — GET/POST/PATCH screening API

### Modified files (12)
- `prisma/schema.prisma` — `ScreeningFlag` enum, `TesterScreeningFlag` model, `screeningExcluded` on `TesterApplicant`
- `src/lib/solver/constraints.ts` — `isScreeningExcluded` field + preFilter integration
- `src/app/api/projects/[projectId]/solve/route.ts` — guard: require screening before solving
- `src/components/layout/workflow-steps.tsx` — add "Screening" step to workflow nav
- `src/app/(dashboard)/.../mapping/page.tsx` — redirect to screening after mapping
- `src/app/api/projects/[projectId]/mapping/route.ts` — advance to screening step
- `src/app/(dashboard)/.../requirements/page.tsx` — use TagInput component
- `src/lib/analysis/claude-client.ts` — add `screenBatchResponses` for screening
- `src/lib/auth.ts` — fix API auth route matching
- `src/lib/solver/constraints.test.ts`, `z3-solver.test.ts` — add `isScreeningExcluded` to test fixtures

## Test plan
- [ ] Run `npx vitest run` — all 117 tests should pass (including 20 new screening tests)
- [ ] Run `npx next build` — clean build with no errors
- [ ] Manual: create a project, upload data, set requirements (verify tag input works), map questions, verify screening step appears and can be run/skipped, then proceed to solver